### PR TITLE
Connect auth hook to server profile

### DIFF
--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -1,16 +1,27 @@
 import { useState, useEffect } from "react";
 
 export function useAuth() {
-  const [user, setUser] = useState(null);
+  const [user, setUser] = useState<any>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    // Check for demo user in localStorage
-    const demoUser = localStorage.getItem('demo-user');
-    if (demoUser) {
-      setUser(JSON.parse(demoUser));
-    }
-    setIsLoading(false);
+    const loadUser = async () => {
+      try {
+        const res = await fetch("/api/profile", { credentials: "include" });
+        if (res.ok) {
+          const data = await res.json();
+          setUser(data);
+        } else {
+          setUser(null);
+        }
+      } catch {
+        setUser(null);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadUser();
   }, []);
 
   return {


### PR DESCRIPTION
## Summary
- Replace demo-localStorage auth with `/api/profile` fetch for real server-backed authentication

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TS errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6892def0dee48325bfcef82580f99d57