### PR TITLE
feat: expand coach dashboard features

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -575,6 +575,22 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Update gymnast details
+  app.patch('/api/gymnasts/:id', isAuthenticated, async (req: any, res) => {
+    try {
+      const user = await storage.getUser(req.user.claims.sub);
+      if (!user || (user.role !== 'admin' && user.role !== 'coach' && user.role !== 'gym_admin')) {
+        return res.status(403).json({ message: "Access denied" });
+      }
+      const updates = insertGymnastSchema.partial().parse(req.body);
+      const gymnast = await storage.updateGymnast(req.params.id, updates);
+      res.json(gymnast);
+    } catch (error) {
+      console.error("Error updating gymnast:", error);
+      res.status(500).json({ message: "Failed to update gymnast" });
+    }
+  });
+
   // Event creation (gym admins only)
   app.post('/api/events', isAuthenticated, async (req: any, res) => {
     try {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -69,6 +69,7 @@ export interface IStorage {
   getAllGymnasts(): Promise<Gymnast[]>;
   updateGymnastApproval(id: string, approved: boolean): Promise<Gymnast>;
   updateGymnastPoints(id: string, points: number): Promise<Gymnast>;
+  updateGymnast(id: string, updates: Partial<InsertGymnast>): Promise<Gymnast>;
   
   // Event operations
   createEvent(event: InsertEvent): Promise<Event>;
@@ -300,6 +301,15 @@ export class DatabaseStorage implements IStorage {
     const [gymnast] = await db
       .update(gymnasts)
       .set({ points, updatedAt: new Date() })
+      .where(eq(gymnasts.id, id))
+      .returning();
+    return gymnast;
+  }
+
+  async updateGymnast(id: string, updates: Partial<InsertGymnast>): Promise<Gymnast> {
+    const [gymnast] = await db
+      .update(gymnasts)
+      .set({ ...updates, updatedAt: new Date() })
       .where(eq(gymnasts.id, id))
       .returning();
     return gymnast;


### PR DESCRIPTION
## Summary
- allow coaches to edit gymnast details and manage challenges from the dashboard
- show upcoming events and enable challenge creation
- support gymnast updates via new API endpoint and storage method

## Testing
- `npm run check` *(fails: Property 'role' does not exist on type 'never', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6892e75767308325b39e6051fae1140e