### PR TITLE
feat(admin): allow editing member details

### DIFF
--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -127,15 +127,15 @@ export default function AdminDashboard() {
   });
 
   const updateMemberMutation = useMutation({
-    mutationFn: async ({ id, role }: { id: string; role: string }) => {
-      return apiRequest('PATCH', `/api/users/${id}/role`, { role });
+    mutationFn: async ({ id, ...updates }: { id: string; firstName: string; lastName: string; email: string; role: string }) => {
+      return apiRequest('PATCH', `/api/users/${id}`, updates);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/api/users'] });
-      toast({ title: "Member role updated successfully" });
+      toast({ title: "Member updated successfully" });
     },
     onError: (error) => {
-      toast({ title: "Error", description: "Failed to update member role", variant: "destructive" });
+      toast({ title: "Error", description: "Failed to update member", variant: "destructive" });
     }
   });
 
@@ -2789,17 +2789,35 @@ export default function AdminDashboard() {
                   <Badge variant={user.role === 'admin' ? 'default' : 'secondary'}>
                     {user.role}
                   </Badge>
-                  <Button 
-                    size="sm" 
+                  <Button
+                    size="sm"
                     variant="outline"
                     onClick={() => {
-                      const newRole = prompt('Enter new role (admin, coach, gym_admin, gymnast, spectator):');
-                      if (newRole && ['admin', 'coach', 'gym_admin', 'gymnast', 'spectator'].includes(newRole)) {
-                        updateMemberMutation.mutate({ id: user.id, role: newRole });
+                      const firstName = prompt('First Name', user.firstName || '') || '';
+                      const lastName = prompt('Last Name', user.lastName || '') || '';
+                      const email = prompt('Email', user.email || '') || '';
+                      const role = prompt(
+                        'Role (admin, coach, gym_admin, gymnast, spectator):',
+                        user.role,
+                      ) || '';
+                      if (
+                        firstName &&
+                        lastName &&
+                        email &&
+                        role &&
+                        ['admin', 'coach', 'gym_admin', 'gymnast', 'spectator'].includes(role)
+                      ) {
+                        updateMemberMutation.mutate({
+                          id: user.id,
+                          firstName,
+                          lastName,
+                          email,
+                          role,
+                        });
                       }
                     }}
                   >
-                    Edit Role
+                    Edit
                   </Button>
                   <Button 
                     size="sm" 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -884,12 +884,27 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (!user || user.role !== 'admin') {
         return res.status(403).json({ message: "Access denied" });
       }
-      
+
       const newUser = await storage.createUser(req.body);
       res.status(201).json(newUser);
     } catch (error) {
       console.error("Error creating user:", error);
       res.status(400).json({ message: "Failed to create user" });
+    }
+  });
+
+  app.patch('/api/users/:id', isAuthenticated, async (req: any, res) => {
+    try {
+      const user = await storage.getUser(req.user.claims.sub);
+      if (!user || user.role !== 'admin') {
+        return res.status(403).json({ message: "Access denied" });
+      }
+
+      const updatedUser = await storage.updateUser(req.params.id, req.body);
+      res.json(updatedUser);
+    } catch (error: any) {
+      console.error("Error updating user:", error);
+      res.status(400).json({ message: error.message || "Failed to update user" });
     }
   });
 


### PR DESCRIPTION
## Summary
- allow admins to update member first name, last name, email, and role
- expose new PATCH /api/users/:id endpoint using storage.updateUser
- extend admin dashboard UI to edit complete member info

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check` (fails: Property 'role' does not exist on type 'never', etc.)

------
https://chatgpt.com/codex/tasks/task_e_68938a88e97c8325a56b16283a826e9a